### PR TITLE
NOTASK: adding support for exposing random port for ssh for non-native networks - like when Docker is on other host (WSL2 case)

### DIFF
--- a/bin/ssh_to_docker
+++ b/bin/ssh_to_docker
@@ -8,11 +8,23 @@ connection_task=${1:-connect}
 
 find $HOME/.ssh/ -name "dock_config_*" -type f -mmin +1 -delete
 
+# finding exposed, randomly chosen port for ssh
+custom_docker_ssh_port="$(docker port $container_name|grep -F -i 22/tcp|rev|cut -f 1 -d ':'|rev)"
+custom_docker_ssh_port="${custom_docker_ssh_port:-22}"
+
+# highly unlikely that Docker will expose random port under 22, it should be > 1024
+# practically it should mean we are just using non-exposed port
+config_container_ip_addr="127.0.0.1"
+if [[ "$custom_docker_ssh_port" == 22 ]];then
+  config_container_ip_addr="$container_ip_addr"
+fi
+
 # This is a temporary entry to be replaced as soon you're trying to connect to another
 # container with another ip_address
 ssh_suffix=$(date +"%T.%N" | sed 's/[^0-9]//g')
 echo "Host dock0-guest"                         >  ~/.ssh/dock_config_$ssh_suffix
-echo "HostName $container_ip_addr"              >> ~/.ssh/dock_config_$ssh_suffix
+echo "HostName $config_container_ip_addr"       >> ~/.ssh/dock_config_$ssh_suffix
+echo "Port $custom_docker_ssh_port"             >> ~/.ssh/dock_config_$ssh_suffix
 echo "StrictHostKeyChecking no"                 >> ~/.ssh/dock_config_$ssh_suffix
 echo "StrictHostKeyChecking no"                 >> ~/.ssh/dock_config_$ssh_suffix
 echo "UserKnownHostsFile /dev/null"             >> ~/.ssh/dock_config_$ssh_suffix

--- a/bin/start_container
+++ b/bin/start_container
@@ -55,7 +55,7 @@ if [[ "$create_new_container" == "yes" ]]; then
 
   # This command both creats AND then starts the container.
   # Written according to Docker documentation here: https://docs.docker.com/engine/reference/commandline/run/
-  create_cmd="docker run -dit --net=$dock_network --name=$project_name $ip_address_option $privileged $mount_options"
+  create_cmd="docker run -dit $DOCKER_RUN_OPTS --net=$dock_network --name=$project_name $ip_address_option $privileged $mount_options"
   #
   # Strip the line of unnecessary whitespace where we have more than one space or tab separating each option or
   # positional argument. It's not strictly necessary, but nice for debug mode when we not only print the nice

--- a/dockrc.template
+++ b/dockrc.template
@@ -9,6 +9,11 @@ DEFAULT_IMAGE_TAG_NAME="stable"
 DEFAULT_IMAGE_FULL_NAME="$DEFAULT_REPO_NAME/$DEFAULT_IMAGE_NAME:$DEFAULT_IMAGE_TAG_NAME"
 BASHJAZZ_PATH="$DOCK_PATH/vendor/bashjazz"
 
+DOCKER_RUN_OPTS=''
+# useful on Windows with WSL2/Docker Desktop (may be MacOs too?) where Docker lives in different VM
+#DOCKER_RUN_OPTS='--expose 22 -P '
+
+
 # Syntax (if you haven't read through Docker documentation):
 # [HOST_PATH]:[GUEST_PATH]:[flags]
 # flags are usually `ro` or `rw` (read-only) or (read-write).


### PR DESCRIPTION
It's not always happens that you have Docker engine on the same machine as docker CLI, thus listening on socket in container, like SSH doesn't automagically means you can reach it from the host with CLI.

Handling such case with `--expose 22` and assigning random port with `-P` in startup options, rewriting ~/.ssh/...config with `127.0.0.1` as Hostname and that random `Port`.

Useful for WSL2 (Windows Subsystem For Linux) + Docker Desktop, which are run in different networks.